### PR TITLE
ci: bump Node to lts/* and update actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '12.x'
+          node-version: 'lts/*'
       - run: |
           yarn
           yarn test


### PR DESCRIPTION
Node 12 in CI is EOL and no longer satisfies transitive dependency requirements (node-releases needs >=18 after the @babel/core bump in #23). Moves CI to lts/* with actions/checkout@v4 and actions/setup-node@v4.